### PR TITLE
Fix typo FE.ProcessService

### DIFF
--- a/src/dataFeeder.js
+++ b/src/dataFeeder.js
@@ -146,7 +146,7 @@ class DataFeeder extends EventEmitter {
             debug(`Process Service stopped: ${processService.intent}, in ${processService.pid} STOPPED`);
 
             this._up2ProcessServices.delete(processService.intent);
-            this._sock.emit("processserviceremoved", FE.processService.fromClass(processService));
+            this._sock.emit("processserviceremoved", FE.ProcessService.fromClass(processService));
         }
     }
 }


### PR DESCRIPTION
This *fix typo* corrects the crash:

```
/data/local/tmp/dist_x86_64/dataFeeder.js:149
            this._sock.emit("processserviceremoved", FE.processService.fromClass(processService));
TypeError: Cannot read property 'fromClass' of undefined
```